### PR TITLE
Added support to turn off lights that were manually turned on, optionally with a different delay

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,10 +137,11 @@ key | optional | type | default | description
 `class` | False | string | AutoMoLi | The name of the Class.
 `room` | False | string | | The "room" used to find matching sensors/light
 `disable_switch_entities` | True | list/string | | One or more Home Assistant Entities as switch for AutoMoLi. If the state of **any** entity is *off*, AutoMoLi is *deactivated*. (Use an *input_boolean* for example)
-`only_own_events` | True | bool | | Track if automoli switched this light on. If not, an existing timer will be deleted and the state will not change
+`only_own_events` | True | bool | None | Track if automoli switched this light on. If not, automoli will not switch the light off. (see below)
 `disable_switch_states` | True | list/string | ["off"] | Custom states for `disable_switch_entities`. If the state of **any** entity is *in this list*, AutoMoLi is *deactivated*. Can be used to disable with `media_players` in `playing` state for example.
 `disable_hue_groups` | False | boolean | | Disable the use of Hue Groups/Scenes
 `delay` | True | integer | 150 | Seconds without motion until lights will switched off. Can be disabled (lights stay always on) with `0`
+`delay_outside_events` | True | integer | same as delay | Seconds without motion until lights will switched off, if they were turned on by an event outside automoli (e.g., manually, via automation, etc.). Can be disabled (lights stay always on) with `0`
 ~~`motion_event`~~ | ~~True~~ | ~~string~~ | | **replaced by `motion_state_on/off`**
 `daytimes` | True | list | *see code* | Different daytimes with light settings (see below)
 `transition_on_daytime_switch` | True | bool | False | directly activate a daytime on its start time (instead to just set it as active daytime used if lights are switched from off to on)
@@ -162,6 +163,14 @@ key | optional | type | default | description
 `name` | False | string | | A name for this daytime
 `delay` | True | integer | 150 | Seconds without motion until lights will switched off. Can be disabled (lights stay always on) with `0`. Setting this will overwrite the global `delay` setting for this daytime.
 `light` | False | integer/string | | Light setting (percent integer value (0-100) in or scene entity
+
+### only_own_events
+
+state | description
+-- | --
+None | Lights will be turned off after motion is detected, regardless of whether AutoMoLi turned the lights on.
+False | Lights will be turned off after motion is detected, regardless of whether AutoMoLi turned the lights on AND after the delay if they were turned on outside AutoMoLi (e.g., manually or via an automation). 
+True | Lights will only be turned off after motion is detected, if AutoMoLi turned the lights on.
 
 ---
 

--- a/apps/automoli/automoli.py
+++ b/apps/automoli/automoli.py
@@ -727,7 +727,7 @@ class AutoMoLi(hass.Hass):  # type: ignore
                 handle = await self.run_in(self.dim_lights, (dim_in_sec))
 
             else:
-                handle = await self.run_in(self.lights_off, delay)
+                handle = await self.run_in(self.lights_off, delay, timeDelay=delay)
 
             self.room.handles_automoli.add(handle)
 
@@ -1053,7 +1053,9 @@ class AutoMoLi(hass.Hass):  # type: ignore
                     self._switched_on_by_automoli.remove(entity)
                 at_least_one_turned_off = True
         if at_least_one_turned_off:
-            self.run_in_thread(self.turned_off, thread=self.notify_thread)
+            self.run_in_thread(
+                self.turned_off, thread=self.notify_thread, timeDelay=_.get("timeDelay")
+            )
 
         # experimental | reset for xiaomi "super motion" sensors | idea from @wernerhp
         # app: https://github.com/wernerhp/appdaemon_aqara_motion_sensors
@@ -1072,7 +1074,9 @@ class AutoMoLi(hass.Hass):  # type: ignore
         # cancel scheduled callbacks
         await self.clear_handles()
 
-        delay = self.active["delay"] if _.get("delay") is None else _.get("delay")
+        delay = (
+            self.active["delay"] if _.get("timeDelay") is None else _.get("timeDelay")
+        )
 
         self.lg(
             f"no motion in {hl(self.room.name.capitalize())} since "

--- a/apps/automoli/automoli.py
+++ b/apps/automoli/automoli.py
@@ -246,7 +246,9 @@ class AutoMoLi(hass.Hass):  # type: ignore
         self.delay = int(self.args.pop("delay", DEFAULT_DELAY))
 
         # delay for events outside AutoMoLi, defaults to same as general delay
-        self.delay_outside_events = int(self.args.pop("delay_outside_events", self.delay))
+        self.delay_outside_events = int(
+            self.args.pop("delay_outside_events", self.delay)
+        )
 
         # directly switch to new daytime light settings
         self.transition_on_daytime_switch: bool = bool(
@@ -376,7 +378,9 @@ class AutoMoLi(hass.Hass):  # type: ignore
         # requirements check:
         # - lights must exist
         # - motion must exist or only using automoli to turn off lights manually turned on after delay
-        if not self.lights or not(self.sensors[EntityType.MOTION.idx] or self.only_own_events == False) :
+        if not self.lights or not (
+            self.sensors[EntityType.MOTION.idx] or self.only_own_events == False
+        ):
             self.lg("")
             self.lg(
                 f"{hl('No lights/sensors')} given and none found with name: "
@@ -597,7 +601,7 @@ class AutoMoLi(hass.Hass):  # type: ignore
     ) -> None:
         """Main handler for motion events."""
 
-        outside_change = (event == "outside_change_detected")
+        outside_change = event == "outside_change_detected"
 
         self.lg(
             f"{stack()[0][3]}: received '{hl(event)}' event from "
@@ -634,6 +638,7 @@ class AutoMoLi(hass.Hass):  # type: ignore
 
         if event != "motion_detected":
             await self.refresh_timer(outside_change=outside_change)
+
     async def outside_change_detected(
         self, entity: str, attribute: str, old: str, new: str, kwargs: dict[str, Any]
     ) -> None:
@@ -688,7 +693,7 @@ class AutoMoLi(hass.Hass):  # type: ignore
 
         self.lg(f"{stack()[0][3]}: cancelled scheduled callbacks", level=logging.DEBUG)
 
-    async def refresh_timer(self, outside_change = False) -> None:
+    async def refresh_timer(self, outside_change=False) -> None:
         """refresh delay timer."""
 
         fnn = f"{stack()[0][3]}:"
@@ -747,7 +752,6 @@ class AutoMoLi(hass.Hass):  # type: ignore
             ) and state in self.disable_switch_states:
                 self.lg(f"{APP_NAME} is disabled by {entity} with {state = }")
                 return True
-
         return False
 
     async def is_blocked(self) -> bool:
@@ -881,7 +885,9 @@ class AutoMoLi(hass.Hass):  # type: ignore
                 await self.call_service("homeassistant/turn_off", entity_id=light)
             self.run_in_thread(self.turned_off, thread=self.notify_thread)
 
-    async def lights_on(self, force: bool = False, outside_change: bool = False) -> None:
+    async def lights_on(
+        self, force: bool = False, outside_change: bool = False
+    ) -> None:
         """Turn on the lights."""
 
         self.lg(
@@ -945,7 +951,7 @@ class AutoMoLi(hass.Hass):  # type: ignore
                         group_name=await self.friendly_name(entity),  # type:ignore
                         scene_name=light_setting,  # type:ignore
                     )
-                    if not outside_change: 
+                    if not outside_change:
                         self._switched_on_by_automoli.add(entity)
                     continue
 
@@ -996,7 +1002,7 @@ class AutoMoLi(hass.Hass):  # type: ignore
                             f" | delay: {hl(natural_time(int(self.active['delay'])))}",
                             icon=ON_ICON,
                         )
-                    if self.only_own_events:
+                    if not outside_change:
                         self._switched_on_by_automoli.add(entity)
 
         else:
@@ -1066,7 +1072,7 @@ class AutoMoLi(hass.Hass):  # type: ignore
         # cancel scheduled callbacks
         await self.clear_handles()
 
-        delay = self.active['delay'] if _.get("delay") is None else _.get("delay")
+        delay = self.active["delay"] if _.get("delay") is None else _.get("delay")
 
         self.lg(
             f"no motion in {hl(self.room.name.capitalize())} since "

--- a/apps/automoli/automoli.py
+++ b/apps/automoli/automoli.py
@@ -640,8 +640,8 @@ class AutoMoLi(hass.Hass):  # type: ignore
     async def outside_change_detected(
         self, entity: str, attribute: str, old: str, new: str, kwargs: dict[str, Any]
     ) -> None:
-        """wrapper for when listening to outside light changes. maps the `state_changed` callback
-        of a light state changing to "on" to the standard motion `event` callback`
+        """wrapper for when listening to outside light changes. on `state_changed` callback
+        of a light  setup a timer by calling `refresh_timer`
         """
         # ensure the change wasn't because of automoli
         if entity in self._switched_on_by_automoli:
@@ -749,6 +749,7 @@ class AutoMoLi(hass.Hass):  # type: ignore
             ) and state in self.disable_switch_states:
                 self.lg(f"{APP_NAME} is disabled by {entity} with {state = }")
                 return True
+
         return False
 
     async def is_blocked(self) -> bool:

--- a/apps/automoli/automoli.py
+++ b/apps/automoli/automoli.py
@@ -641,7 +641,7 @@ class AutoMoLi(hass.Hass):  # type: ignore
         self, entity: str, attribute: str, old: str, new: str, kwargs: dict[str, Any]
     ) -> None:
         """wrapper for when listening to outside light changes. on `state_changed` callback
-        of a light  setup a timer by calling `refresh_timer`
+        of a light setup a timer by calling `refresh_timer`
         """
         # ensure the change wasn't because of automoli
         if entity in self._switched_on_by_automoli:

--- a/apps/automoli/automoli.py
+++ b/apps/automoli/automoli.py
@@ -626,7 +626,7 @@ class AutoMoLi(hass.Hass):  # type: ignore
             await self.lights_on()
         else:
             refresh = ""
-            if event != "motion_detected":
+            if event != "motion_state_changed_detection":
                 refresh = " → refreshing timer"
             self.lg(
                 f"{stack()[0][3]}: lights in {self.room.name.capitalize()} already on {refresh}"


### PR DESCRIPTION
If only_own_events is False, then added state change listeners for all lights. Then, when a state change occurs outside automoli, manually setup the timers. Also added an additional, optional config property, delay_outside_events, that if present will override the standard delay in the cases when the light has been turned on manually.

delay_outside_events is useful, for example, when you want lights to go off quickly when turned on automatically, but have a longer delay if a light switch is used. I have a 3 minute delay in a hallway (assuming someone is just passing through) but have set delay_outside_events to 15 minutes if the light switch is used (and someone might need to linger in the hallway).

In an attempt to minimize backward compatibility issues, the code assumes that if only_own_events is not present in the config, it is None and not False.