### PR TITLE
Bug fixes for multiple lights, one daytime, and log/readme cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,8 +151,8 @@ key | optional | type | default | description
 `illuminance_threshold` | True | integer |  | If illuminance is *above* this value, lights will *not switched on*
 `humidity` | True | list/string |  | Humidity sensor entities
 `humidity_threshold` | True | integer |  | If humidity is *above* this value, lights will *not switched off*
-`motion_state_on` | True | integer | | If using motion sensors which don't send events if already activated, like Xiaomi do, add this to your config with "on". This will listen to state changes instead
-`motion_state_off` | True | integer | | If using motion sensors which don't send events if already activated, like Xiaomi do, add this to your config with "off". This will listen to the state changes instead.
+`motion_state_on` | True | integer | | If using motion sensors which don't send events if already activated, like Xiaomi do with the Xiaomi Gateway (Aqara) integration, add this to your config with "on". This will listen to state changes instead
+`motion_state_off` | True | integer | | If using motion sensors which don't send events if already activated, like Xiaomi do with the Xiaomi Gateway (Aqara) integration, add this to your config with "off". This will listen to the state changes instead
 `debug_log` | True | bool | false | Activate debug logging (for this room)
 
 ### daytimes
@@ -163,6 +163,8 @@ key | optional | type | default | description
 `name` | False | string | | A name for this daytime
 `delay` | True | integer | 150 | Seconds without motion until lights will switched off. Can be disabled (lights stay always on) with `0`. Setting this will overwrite the global `delay` setting for this daytime.
 `light` | False | integer/string | | Light setting (percent integer value (0-100) in or scene entity
+
+Note: If there is only one daytime, the light and delay settings will be applied for the entire day, regardless of the starttime.
 
 ### only_own_events
 


### PR DESCRIPTION
- Ensure that if a room has multiple lights, all lights will be turned on based on motion events
- [Workaround for issue 86]  Allow a single daytime such as:
  {starttime: "00:00", name: "allday", light: 100}
- Clarified in documentation that motion events are only sent if you have the Xioami Gateway integration (not just if you have Xioami / Aqara motion sensors)
- Added and made minor updates to a few log statements to help with debugging